### PR TITLE
Fixed bug regarding DYLD_LIBRARY_PATH.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,12 +154,12 @@ if [[ $WRITE_PATH_TO_PROFILE == 1 ]]; then
     echo "
 
 export PATH=$PREFIX/bin:\$PATH  # Added automatically by torch-dist
-export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist" >> $RC_FILE
+export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH  # Added automatically by torch-dist" >> $RC_FILE
     echo "
 
 export PATH=$PREFIX/bin:\$PATH  # Added automatically by torch-dist
-export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist" >> $HOME/.profile
+export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH  # Added automatically by torch-dist" >> $HOME/.profile
 
 else


### PR DESCRIPTION
The DYLD_LIBRARY_PATH is not added to the bashrc because the echoed string
is already closed on the previous line. Problem introduced in earlier
commit (ba196a20d6a7d80ff5c6ed59e9a872d0954db776).