### PR TITLE
fail on error; show commands; CUDA optional; ipython failure non-fatal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,9 @@ cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rocksp
 cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec
 
 export PATH=$OLDPATH # Restore anaconda distribution if we took it out.
+set +e
 cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make
+set -e
 
 
 RC_FILE=0

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ THIS_DIR=$(cd $(dirname $0); pwd)
 PREFIX="${THIS_DIR}/install"
 BATCH_INSTALL=0
 
+export LUAROCKS_CONFIG=${THIS_DIR}/install/etc/luarocks/config.lua
+
 while getopts 'bh:' x; do
     case "$x" in
         h) 

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,10 @@ else
     fi
 fi
 
+echo "export PATH=$PREFIX/bin:\$PATH">${THIS_DIR}/activate
+echo "export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH" >>${THIS_DIR}/activate
+echo "export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH" >>${THIS_DIR}/activate
+
 if [[ $WRITE_PATH_TO_PROFILE == 1 ]]; then
     echo "
 
@@ -181,5 +185,8 @@ add the following lines to your shell profile:
 export PATH=$PREFIX/bin:\$PATH
 export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH 
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH 
+
+or simply:
+source ${THIS_DIR}/activate
 "
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -x
+
 THIS_DIR=$(cd $(dirname $0); pwd)
 PREFIX="${THIS_DIR}/install"
 BATCH_INSTALL=0
@@ -51,11 +54,15 @@ make && make install
 cd ..
 
 # Check for a CUDA install (using nvcc instead of nvidia-smi for cross-platform compatibility)
-path_to_nvcc=$(which nvcc)
-path_to_nvidiasmi=$(which nvidia-smi)
+if [[ ! -v NOCUDA ]]; then {
+    path_to_nvcc=$(which nvcc)
+    path_to_nvidiasmi=$(which nvidia-smi)
+} fi
 
 # check if we are on mac and fix RPATH for local install
+set +e
 path_to_install_name_tool=$(which install_name_tool)
+set -e
 if [ -x "$path_to_install_name_tool" ]
 then
    install_name_tool -id ${PREFIX}/lib/libluajit.dylib ${PREFIX}/lib/libluajit.dylib


### PR DESCRIPTION
- fail on error (`set -e`)
- show commands  (`set -x`)
- CUDA optional  (`NOCUDA=1 ./install.sh`)
- ipython failure non-fatal  (surrounded by `set +e`, `set -e`)