### PR TITLE
setup LUA_PATH and LUA_CPATH; exit when luarocks fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,9 @@ then
    install_name_tool -id ${PREFIX}/lib/libluajit.dylib ${PREFIX}/lib/libluajit.dylib
 fi
 
+setup_lua_env_cmd=$($PREFIX/bin/luarocks path -bin)
+eval "$setup_lua_env_cmd"
+
 $PREFIX/bin/luarocks install luafilesystem || exit 1
 $PREFIX/bin/luarocks install penlight || exit 1
 $PREFIX/bin/luarocks install lua-cjson || exit 1
@@ -114,6 +117,7 @@ else
 Non-standard shell $SHELL detected. You might want to 
 add the following lines to your shell profile:
 
+$setup_lua_env_cmd
 export PATH=$PREFIX/bin:\$PATH
 export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH 
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH 
@@ -153,11 +157,13 @@ fi
 if [[ $WRITE_PATH_TO_PROFILE == 1 ]]; then
     echo "
 
+$setup_lua_env_cmd
 export PATH=$PREFIX/bin:\$PATH  # Added automatically by torch-dist
 export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH  # Added automatically by torch-dist" >> $RC_FILE
     echo "
 
+$setup_lua_env_cmd
 export PATH=$PREFIX/bin:\$PATH  # Added automatically by torch-dist
 export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH  # Added automatically by torch-dist
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH  # Added automatically by torch-dist" >> $HOME/.profile
@@ -169,6 +175,7 @@ Not updating your shell profile.
 You might want to 
 add the following lines to your shell profile:
 
+$setup_lua_env_cmd
 export PATH=$PREFIX/bin:\$PATH
 export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH 
 export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH 

--- a/install.sh
+++ b/install.sh
@@ -64,45 +64,45 @@ fi
 setup_lua_env_cmd=$($PREFIX/bin/luarocks path -bin)
 eval "$setup_lua_env_cmd"
 
-$PREFIX/bin/luarocks install luafilesystem || exit 1
-$PREFIX/bin/luarocks install penlight || exit 1
-$PREFIX/bin/luarocks install lua-cjson || exit 1
+$PREFIX/bin/luarocks install luafilesystem
+$PREFIX/bin/luarocks install penlight
+$PREFIX/bin/luarocks install lua-cjson
 
-cd ${THIS_DIR}/pkg/sundown && $PREFIX/bin/luarocks make rocks/sundown-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/cwrap && $PREFIX/bin/luarocks make rocks/cwrap-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/paths && $PREFIX/bin/luarocks make rocks/paths-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/dok && $PREFIX/bin/luarocks make rocks/dok-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/gnuplot && $PREFIX/bin/luarocks make rocks/gnuplot-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/exe/qtlua && $PREFIX/bin/luarocks make rocks/qtlua-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/exe/trepl && $PREFIX/bin/luarocks make || exit 1
-cd ${THIS_DIR}/exe/env && $PREFIX/bin/luarocks make || exit 1
-cd ${THIS_DIR}/pkg/sys && $PREFIX/bin/luarocks make sys-1.1-0.rockspec || exit 1
-cd ${THIS_DIR}/pkg/xlua && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec || exit 1
-cd ${THIS_DIR}/extra/nn && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/extra/nnx && $PREFIX/bin/luarocks make nnx-0.1-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/sundown && $PREFIX/bin/luarocks make rocks/sundown-scm-1.rockspec
+cd ${THIS_DIR}/pkg/cwrap && $PREFIX/bin/luarocks make rocks/cwrap-scm-1.rockspec
+cd ${THIS_DIR}/pkg/paths && $PREFIX/bin/luarocks make rocks/paths-scm-1.rockspec
+cd ${THIS_DIR}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec
+cd ${THIS_DIR}/pkg/dok && $PREFIX/bin/luarocks make rocks/dok-scm-1.rockspec
+cd ${THIS_DIR}/pkg/gnuplot && $PREFIX/bin/luarocks make rocks/gnuplot-scm-1.rockspec
+cd ${THIS_DIR}/exe/qtlua && $PREFIX/bin/luarocks make rocks/qtlua-scm-1.rockspec
+cd ${THIS_DIR}/exe/trepl && $PREFIX/bin/luarocks make
+cd ${THIS_DIR}/exe/env && $PREFIX/bin/luarocks make
+cd ${THIS_DIR}/pkg/sys && $PREFIX/bin/luarocks make sys-1.1-0.rockspec
+cd ${THIS_DIR}/pkg/xlua && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec
+cd ${THIS_DIR}/extra/nn && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec
+cd ${THIS_DIR}/extra/nnx && $PREFIX/bin/luarocks make nnx-0.1-1.rockspec
 
 if [ -x "$path_to_nvcc" ] || [ -x "$path_to_nvidiasmi" ]
 then
-    cd ${THIS_DIR}/extra/cutorch && $PREFIX/bin/luarocks make rocks/cutorch-scm-1.rockspec || exit 1
-    cd ${THIS_DIR}/extra/cunn && $PREFIX/bin/luarocks make rocks/cunn-scm-1.rockspec || exit 1
-    cd ${THIS_DIR}/extra/cunnx && $PREFIX/bin/luarocks make rocks/cunnx-scm-1.rockspec || exit 1
-    cd ${THIS_DIR}/extra/cudnn && $PREFIX/bin/luarocks make cudnn-scm-1.rockspec || exit 1
+    cd ${THIS_DIR}/extra/cutorch && $PREFIX/bin/luarocks make rocks/cutorch-scm-1.rockspec
+    cd ${THIS_DIR}/extra/cunn && $PREFIX/bin/luarocks make rocks/cunn-scm-1.rockspec
+    cd ${THIS_DIR}/extra/cunnx && $PREFIX/bin/luarocks make rocks/cunnx-scm-1.rockspec
+    cd ${THIS_DIR}/extra/cudnn && $PREFIX/bin/luarocks make cudnn-scm-1.rockspec
 fi
 
-cd ${THIS_DIR}/pkg/qttorch && $PREFIX/bin/luarocks make rocks/qttorch-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/pkg/image && $PREFIX/bin/luarocks make image-1.1.alpha-0.rockspec || exit 1
-cd ${THIS_DIR}/pkg/optim && $PREFIX/bin/luarocks make optim-1.0.5-0.rockspec || exit 1
-cd ${THIS_DIR}/extra/sdl2 && $PREFIX/bin/luarocks make rocks/sdl2-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/extra/threads && $PREFIX/bin/luarocks make rocks/threads-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/extra/graphicsmagick && $PREFIX/bin/luarocks make graphicsmagick-1.scm-0.rockspec || exit 1
-cd ${THIS_DIR}/extra/argcheck && $PREFIX/bin/luarocks make rocks/argcheck-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/extra/audio && $PREFIX/bin/luarocks make audio-0.1-0.rockspec || exit 1
-cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rockspec || exit 1
-cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/qttorch && $PREFIX/bin/luarocks make rocks/qttorch-scm-1.rockspec
+cd ${THIS_DIR}/pkg/image && $PREFIX/bin/luarocks make image-1.1.alpha-0.rockspec
+cd ${THIS_DIR}/pkg/optim && $PREFIX/bin/luarocks make optim-1.0.5-0.rockspec
+cd ${THIS_DIR}/extra/sdl2 && $PREFIX/bin/luarocks make rocks/sdl2-scm-1.rockspec
+cd ${THIS_DIR}/extra/threads && $PREFIX/bin/luarocks make rocks/threads-scm-1.rockspec
+cd ${THIS_DIR}/extra/graphicsmagick && $PREFIX/bin/luarocks make graphicsmagick-1.scm-0.rockspec
+cd ${THIS_DIR}/extra/argcheck && $PREFIX/bin/luarocks make rocks/argcheck-scm-1.rockspec
+cd ${THIS_DIR}/extra/audio && $PREFIX/bin/luarocks make audio-0.1-0.rockspec
+cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rockspec
+cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec
 
 export PATH=$OLDPATH # Restore anaconda distribution if we took it out.
-cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make || exit 1
+cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make
 
 
 RC_FILE=0

--- a/install.sh
+++ b/install.sh
@@ -61,45 +61,45 @@ then
    install_name_tool -id ${PREFIX}/lib/libluajit.dylib ${PREFIX}/lib/libluajit.dylib
 fi
 
-$PREFIX/bin/luarocks install luafilesystem
-$PREFIX/bin/luarocks install penlight
-$PREFIX/bin/luarocks install lua-cjson
+$PREFIX/bin/luarocks install luafilesystem || exit 1
+$PREFIX/bin/luarocks install penlight || exit 1
+$PREFIX/bin/luarocks install lua-cjson || exit 1
 
-cd ${THIS_DIR}/pkg/sundown && $PREFIX/bin/luarocks make rocks/sundown-scm-1.rockspec
-cd ${THIS_DIR}/pkg/cwrap && $PREFIX/bin/luarocks make rocks/cwrap-scm-1.rockspec
-cd ${THIS_DIR}/pkg/paths && $PREFIX/bin/luarocks make rocks/paths-scm-1.rockspec
-cd ${THIS_DIR}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec
-cd ${THIS_DIR}/pkg/dok && $PREFIX/bin/luarocks make rocks/dok-scm-1.rockspec
-cd ${THIS_DIR}/pkg/gnuplot && $PREFIX/bin/luarocks make rocks/gnuplot-scm-1.rockspec
-cd ${THIS_DIR}/exe/qtlua && $PREFIX/bin/luarocks make rocks/qtlua-scm-1.rockspec
-cd ${THIS_DIR}/exe/trepl && $PREFIX/bin/luarocks make
-cd ${THIS_DIR}/exe/env && $PREFIX/bin/luarocks make
-cd ${THIS_DIR}/pkg/sys && $PREFIX/bin/luarocks make sys-1.1-0.rockspec
-cd ${THIS_DIR}/pkg/xlua && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec
-cd ${THIS_DIR}/extra/nn && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec
-cd ${THIS_DIR}/extra/nnx && $PREFIX/bin/luarocks make nnx-0.1-1.rockspec
+cd ${THIS_DIR}/pkg/sundown && $PREFIX/bin/luarocks make rocks/sundown-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/cwrap && $PREFIX/bin/luarocks make rocks/cwrap-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/paths && $PREFIX/bin/luarocks make rocks/paths-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/dok && $PREFIX/bin/luarocks make rocks/dok-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/gnuplot && $PREFIX/bin/luarocks make rocks/gnuplot-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/exe/qtlua && $PREFIX/bin/luarocks make rocks/qtlua-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/exe/trepl && $PREFIX/bin/luarocks make || exit 1
+cd ${THIS_DIR}/exe/env && $PREFIX/bin/luarocks make || exit 1
+cd ${THIS_DIR}/pkg/sys && $PREFIX/bin/luarocks make sys-1.1-0.rockspec || exit 1
+cd ${THIS_DIR}/pkg/xlua && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec || exit 1
+cd ${THIS_DIR}/extra/nn && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/extra/nnx && $PREFIX/bin/luarocks make nnx-0.1-1.rockspec || exit 1
 
 if [ -x "$path_to_nvcc" ] || [ -x "$path_to_nvidiasmi" ]
 then
-    cd ${THIS_DIR}/extra/cutorch && $PREFIX/bin/luarocks make rocks/cutorch-scm-1.rockspec
-    cd ${THIS_DIR}/extra/cunn && $PREFIX/bin/luarocks make rocks/cunn-scm-1.rockspec
-    cd ${THIS_DIR}/extra/cunnx && $PREFIX/bin/luarocks make rocks/cunnx-scm-1.rockspec
-    cd ${THIS_DIR}/extra/cudnn && $PREFIX/bin/luarocks make cudnn-scm-1.rockspec
+    cd ${THIS_DIR}/extra/cutorch && $PREFIX/bin/luarocks make rocks/cutorch-scm-1.rockspec || exit 1
+    cd ${THIS_DIR}/extra/cunn && $PREFIX/bin/luarocks make rocks/cunn-scm-1.rockspec || exit 1
+    cd ${THIS_DIR}/extra/cunnx && $PREFIX/bin/luarocks make rocks/cunnx-scm-1.rockspec || exit 1
+    cd ${THIS_DIR}/extra/cudnn && $PREFIX/bin/luarocks make cudnn-scm-1.rockspec || exit 1
 fi
 
-cd ${THIS_DIR}/pkg/qttorch && $PREFIX/bin/luarocks make rocks/qttorch-scm-1.rockspec
-cd ${THIS_DIR}/pkg/image && $PREFIX/bin/luarocks make image-1.1.alpha-0.rockspec
-cd ${THIS_DIR}/pkg/optim && $PREFIX/bin/luarocks make optim-1.0.5-0.rockspec
-cd ${THIS_DIR}/extra/sdl2 && $PREFIX/bin/luarocks make rocks/sdl2-scm-1.rockspec
-cd ${THIS_DIR}/extra/threads && $PREFIX/bin/luarocks make rocks/threads-scm-1.rockspec
-cd ${THIS_DIR}/extra/graphicsmagick && $PREFIX/bin/luarocks make graphicsmagick-1.scm-0.rockspec
-cd ${THIS_DIR}/extra/argcheck && $PREFIX/bin/luarocks make rocks/argcheck-scm-1.rockspec
-cd ${THIS_DIR}/extra/audio && $PREFIX/bin/luarocks make audio-0.1-0.rockspec
-cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rockspec
-cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec
+cd ${THIS_DIR}/pkg/qttorch && $PREFIX/bin/luarocks make rocks/qttorch-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/pkg/image && $PREFIX/bin/luarocks make image-1.1.alpha-0.rockspec || exit 1
+cd ${THIS_DIR}/pkg/optim && $PREFIX/bin/luarocks make optim-1.0.5-0.rockspec || exit 1
+cd ${THIS_DIR}/extra/sdl2 && $PREFIX/bin/luarocks make rocks/sdl2-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/extra/threads && $PREFIX/bin/luarocks make rocks/threads-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/extra/graphicsmagick && $PREFIX/bin/luarocks make graphicsmagick-1.scm-0.rockspec || exit 1
+cd ${THIS_DIR}/extra/argcheck && $PREFIX/bin/luarocks make rocks/argcheck-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/extra/audio && $PREFIX/bin/luarocks make audio-0.1-0.rockspec || exit 1
+cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rockspec || exit 1
+cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec || exit 1
 
 export PATH=$OLDPATH # Restore anaconda distribution if we took it out.
-cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make
+cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make || exit 1
 
 
 RC_FILE=0


### PR DESCRIPTION
When I use install.sh in fedora22, 

cd ${THIS_DIR}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec 

will fail because cwrap not found.

The issue is $PREFIX/bin/luajit will not search package in $PREFIX,

$PREFIX/bin/luarocks path -bin

ouput the required env variable.

We should setup these variables during installation and save these to profile.

And if some luarocks install fails, install.sh should fail immediately.