### PR TITLE
Ensure iTorch can find openssl libs on MacOS.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,8 +102,11 @@ cd ${THIS_DIR}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rocksp
 cd ${THIS_DIR}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec
 
 export PATH=$OLDPATH # Restore anaconda distribution if we took it out.
-cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make
-
+if [[ `uname` == "Darwin" ]]; then
+    cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make OPENSSL_DIR=/usr/local/opt/openssl/
+else
+    cd ${THIS_DIR}/extra/iTorch && $PREFIX/bin/luarocks make
+fi
 
 RC_FILE=0
 DEFAULT=yes


### PR DESCRIPTION
On MacOS, if openssl is installed with homebrew, luacrypto will not find the libs and fail to build. luacrypto is a dependency of iTorch.