### PR TITLE
README.md: Avoid use of -k (--insecure) in curl for security reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@ Self-contained Torch installation
 ============
 
 Install dependencies. Uses `apt-get` on Ubuntu, which might require `sudo`. Uses `brew` on OSX.
-```
+```sh
 curl -sk https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
 ```
 
 Install this repo, which installs the torch distribution, with a lot of nice goodies.
-```
+```sh
 git clone https://github.com/torch/distro.git ~/torch --recursive
 cd ~/torch; ./install.sh
 ```
 
 Now, everything should be installed. Source your profile, or open a new shell
-```
+```sh
 source ~/.bashrc  # or ~/.zshrc.
 th -e "print 'I just installed Torch! Yesss.'"
 ```
 
 Note: If you use a non-standard shell, you'll want to add the following directories to your `PATH`
-```
+```sh
 export PATH=$HOME/torch/install/bin:$PATH
 export LD_LIBRARY_PATH=$HOME/torch/install/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$HOME/torch/install/lib:$DYLD_LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Self-contained Torch installation
 
 Install dependencies. Uses `apt-get` on Ubuntu, which might require `sudo`. Uses `brew` on OSX.
 ```sh
-curl -sk https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
+curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
 ```
 
 Install this repo, which installs the torch distribution, with a lot of nice goodies.


### PR DESCRIPTION
The `-k` (`--insecure`) flag disables the TLS certificate verifications, allowing anyone to impersonate the source to serve a malicious version of the script.  See also: https://github.com/torch/torch.github.io/pull/20

Also changed `source` to `.` in the code since they are synonymous.