### PR TITLE
improve the test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,15 @@
-LUA=$(which luajit)
-LUA=${LUA:-"lua"}
-echo $LUA
+set -e
+
+LUA=$(which luajit lua | head -n 1)
+
+if [ ! -x "$LUA" ]
+then
+    echo "Neither luajit nor lua found in path"
+    exit 1
+fi
+
+echo "Using Lua at:"
+echo "$LUA"
 
 #smoke tests
 $LUA -lpaths     -e "print('paths loaded succesfully')"
@@ -13,7 +22,7 @@ $LUA -lcwrap     -e "print('cwrap loaded succesfully')"
 $LUA -lgnuplot   -e "print('gnuplot loaded succesfully')"
 $LUA -loptim     -e "print('optim loaded succesfully')"
 $LUA -lsys       -e "print('sys loaded succesfully')"
-$LUA -lxlua      -e "print('x$LUA loaded succesfully')"
+$LUA -lxlua      -e "print('x$(basename $LUA) loaded succesfully')"
 $LUA -largcheck  -e "print('argcheck loaded succesfully')"
 $LUA -lgraph     -e "print('graph loaded succesfully')"
 $LUA -lnn        -e "print('nn loaded succesfully')"
@@ -24,15 +33,14 @@ $LUA -lthreads   -e "print('threads loaded succesfully')"
 th -ltorch -e "torch.test()"
 th -lnn    -e "nn.test()"
 
-if [ $LUA == 'luajit' ];
+if [ $(basename $LUA) = "luajit" ]
 then
-    $LUA -lsundown   -e "print('sundown loaded succesfully')"
-    $LUA -lsignal    -e "print('signal loaded succesfully')"
-    $LUA -lgraphicsmagick -e "print('graphicsmagick loaded succesfully')"
-    $LUA -lfftw3     -e "print('fftw3 loaded succesfully')"
-    $LUA -laudio     -e "print('audio loaded succesfully')"
+    $LUA -lsundown         -e "print('sundown loaded succesfully')"
+    $LUA -lsignal          -e "print('signal loaded succesfully')"
+    $LUA -lgraphicsmagick  -e "print('graphicsmagick loaded succesfully')"
+    $LUA -lfftw3           -e "print('fftw3 loaded succesfully')"
+    $LUA -laudio           -e "print('audio loaded succesfully')"
 fi
-
 
 # CUDA tests
 path_to_nvcc=$(which nvcc)
@@ -42,7 +50,7 @@ if [ -x "$path_to_nvcc" ] || [ -x "$path_to_nvidiasmi" ]
 then
     $LUA -lcutorch -e "print('cutorch loaded succesfully')"
     $LUA -lcunn -e "print('cunn loaded succesfully')"
-    if [ $LUA == 'luajit' ];
+    if [ $(basename $LUA) = "luajit" ];
     then
         $LUA -lcudnn -e "print('cudnn loaded succesfully')"
     fi


### PR DESCRIPTION
- Make the test actually fail when something goes wrong (`set -e`)
- Compare to `basename $LUA` to actually get the value `luajit`
- Substitute `==` with `=` to make the test work