### PR TITLE
Fix install.sh `luarocks path -bin` typo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ then
    install_name_tool -id ${PREFIX}/lib/libluajit.dylib ${PREFIX}/lib/libluajit.dylib
 fi
 
-setup_lua_env_cmd=$($PREFIX/bin/luarocks path -bin)
+setup_lua_env_cmd=$($PREFIX/bin/luarocks path --bin)
 eval "$setup_lua_env_cmd"
 
 echo "Installing common Lua packages"


### PR DESCRIPTION
`-bin` doesn't exist, it's `--bin`. But since apparently nobody ever complained, I guess it's not needed because all binaries are run using full path.
Although since it doesn't seem to be needed you might rather want to remove it entirely?

PS: Using `LuaRocks 2.2.0beta1`.