### PR TITLE
Fix dependency installation on Amazon Linux (amzn)

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -268,9 +268,16 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                             gcc-c++ gcc-gfortran git gnuplot unzip \
                             nodejs npm libjpeg-turbo-devel libpng-devel \
                             ImageMagick GraphicsMagick-devel fftw-devel \
-                            sox-devel sox zeromq3-devel \
-                            qt-devel qtwebkit-devel sox-plugins-freeworld \
-                            ipython libgfortran
+                            libgfortran python27-pip git openssl-devel
+
+        #
+        # These libraries are missing from amzn linux
+        # sox-devel sox sox-plugins-freeworld qt-devel qtwebkit-devel
+        #
+
+        sudo yum --enablerepo=epel install -y zeromq3-devel
+        sudo pip install ipython
+
         install_openblas || true
     fi
 


### PR DESCRIPTION
Torch failed to compile on Amazon Linux due to missing libraries. Install all possible dependencies, now it's compiling clean on a fresh instance. sox and qt are not available due to the Amazon's policy, they are commented out. It's strange but ipython is not available on Amazon Linux for python 2.7 or never, I decided to use pip to install it which works fine.

Tested on the latest Amazon Linux version.