### PR TITLE
install-deps: remove cask install command

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -76,7 +76,6 @@ if [[ `uname` == 'Darwin' ]]; then
     brew install git readline cmake wget qt
     brew install libjpeg imagemagick zeromq graphicsmagick openssl
     brew link readline --force
-    brew install caskroom/cask/brew-cask
     brew cask install xquartz
     brew remove gnuplot
     brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua


### PR DESCRIPTION
That command hasn’t been needed for a while. In fact, it no longer works. Homebrew now auto-installs homebrew-cask the first time a `brew cask` command is issues.

Closes https://github.com/torch/distro/issues/88.