### PR TITLE
Test CUDA builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_script:
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
 - git clone https://github.com/szagoruyko/distro.git ~/torch --recursive
 - sudo -E bash ~/torch/travis_cuda_install.sh
+- export PATH=/usr/local/cuda/bin/:$PATH
 script: 
 - cd ~/torch && ./install.sh -b
 - source ~/torch/install/bin/torch-activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ script:
 - export PATH=/usr/local/cuda/bin/:$PATH
 - cd ~/torch && ./install.sh -b
 - source ~/torch/install/bin/torch-activate
-- export PATH=#PRE_PATH
+- export PATH=$PRE_PATH
 - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ compiler:
 cache:
   directories:
   - $HOME/OpenBlasInstall
-sudo: false
 env:
   - TORCH_LUA_VERSION=LUAJIT21
   - TORCH_LUA_VERSION=LUA51
@@ -47,7 +46,7 @@ before_script:
 - export ROOT_TRAVIS_DIR=$(pwd)
 - export INSTALL_PREFIX=~/torch/install
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
-- git clone https://github.com/torch/distro.git ~/torch --recursive
+- git clone https://github.com/szagoruyko/distro.git ~/torch --recursive
 - sudo -E bash ~/torch/travis_cuda_install.sh
 script: 
 - cd ~/torch && ./install.sh -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,7 @@ before_script:
 - git clone https://github.com/szagoruyko/distro.git ~/torch --recursive
 - sudo -E bash ~/torch/travis_cuda_install.sh
 script: 
-- export PRE_PATH=$PATH
 - export PATH=/usr/local/cuda/bin/:$PATH
 - cd ~/torch && ./install.sh -b
-- export PATH=$PRE_PATH
 - source ~/torch/install/bin/torch-activate
 - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 - export INSTALL_PREFIX=~/torch/install
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
 - git clone https://github.com/torch/distro.git ~/torch --recursive
-- sudo -E bash ~/torch/travis_cuda_install.sh
+- sudo -E $ROOT_TRAVIS_DIR/travis_cuda_install.sh
 script: 
 - export PATH=/usr/local/cuda/bin/:$PATH
 - cd ~/torch && ./install.sh -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_script:
 - export INSTALL_PREFIX=~/torch/install
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
 - git clone https://github.com/torch/distro.git ~/torch --recursive
+- sudo -E bash ~/torch/travis_cuda_install.sh
 script: 
 - cd ~/torch && ./install.sh -b
 - source ~/torch/install/bin/torch-activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ script:
 - export PRE_PATH=$PATH
 - export PATH=/usr/local/cuda/bin/:$PATH
 - cd ~/torch && ./install.sh -b
-- source ~/torch/install/bin/torch-activate
 - export PATH=$PRE_PATH
+- source ~/torch/install/bin/torch-activate
 - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler:
 cache:
   directories:
   - $HOME/OpenBlasInstall
+sudo: required
 env:
   - TORCH_LUA_VERSION=LUAJIT21
   - TORCH_LUA_VERSION=LUA51
@@ -46,7 +47,7 @@ before_script:
 - export ROOT_TRAVIS_DIR=$(pwd)
 - export INSTALL_PREFIX=~/torch/install
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
-- git clone https://github.com/szagoruyko/distro.git ~/torch --recursive
+- git clone https://github.com/torch/distro.git ~/torch --recursive
 - sudo -E bash ~/torch/travis_cuda_install.sh
 script: 
 - export PATH=/usr/local/cuda/bin/:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,10 @@ before_script:
 -  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
 - git clone https://github.com/szagoruyko/distro.git ~/torch --recursive
 - sudo -E bash ~/torch/travis_cuda_install.sh
-- export PATH=/usr/local/cuda/bin/:$PATH
 script: 
+- export PRE_PATH=$PATH
+- export PATH=/usr/local/cuda/bin/:$PATH
 - cd ~/torch && ./install.sh -b
 - source ~/torch/install/bin/torch-activate
+- export PATH=#PRE_PATH
 - ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -42,13 +42,7 @@ then
     $LUA -laudio           -e "print('audio loaded succesfully')"
 fi
 
-# CUDA tests
-set +e 
-path_to_nvcc=$(which nvcc)
-path_to_nvidiasmi=$(which nvidia-smi)
-set -e 
-
-if [ -x "$path_to_nvcc" ] || [ -x "$path_to_nvidiasmi" ]
+if `$LUA -lcutorch -e ""`
 then
     $LUA -lcutorch -e "print('cutorch loaded succesfully')"
     $LUA -lcunn -e "print('cunn loaded succesfully')"

--- a/travis_cuda_install.sh
+++ b/travis_cuda_install.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env sh
 
-CUDA_VERSION=6-5
-CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
-CUDA_FILE=/tmp/cuda_install.deb
+if [[ `uname` == 'Linux' ]]; then
+  CUDA_VERSION=6-5
+  CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
+  CUDA_FILE=/tmp/cuda_install.deb
 
-curl $CUDA_URL -o $CUDA_FILE
-dpkg -i $CUDA_FILE
-rm -f $CUDA_FILE
-apt-get -y update
-apt-get -y install \
-  cuda-core-${CUDA_VERSION} \
-  cuda-cublas-${CUDA_VERSION} \
-  cuda-cublas-dev-${CUDA_VERSION} \
-  cuda-cudart-${CUDA_VERSION} \
-  cuda-cudart-dev-${CUDA_VERSION} \
-  cuda-curand-${CUDA_VERSION} \
-  cuda-curand-dev-${CUDA_VERSION} \
-  cuda-cusparse-${CUDA_VERSION} \
-  cuda-cusparse-dev-${CUDA_VERSION}
-ln -s /usr/local/cuda-6.5 /usr/local/cuda
+  curl $CUDA_URL -o $CUDA_FILE
+  dpkg -i $CUDA_FILE
+  rm -f $CUDA_FILE
+  apt-get -y update
+  apt-get -y install \
+    cuda-core-${CUDA_VERSION} \
+    cuda-cublas-${CUDA_VERSION} \
+    cuda-cublas-dev-${CUDA_VERSION} \
+    cuda-cudart-${CUDA_VERSION} \
+    cuda-cudart-dev-${CUDA_VERSION} \
+    cuda-curand-${CUDA_VERSION} \
+    cuda-curand-dev-${CUDA_VERSION} \
+    cuda-cusparse-${CUDA_VERSION} \
+    cuda-cusparse-dev-${CUDA_VERSION}
+  ln -s /usr/local/cuda-6.5 /usr/local/cuda
+fi

--- a/travis_cuda_install.sh
+++ b/travis_cuda_install.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 CUDA_VERSION=6-5
-
 CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
 CUDA_FILE=/tmp/cuda_install.deb
+
 curl $CUDA_URL -o $CUDA_FILE
 dpkg -i $CUDA_FILE
 rm -f $CUDA_FILE

--- a/travis_cuda_install.sh
+++ b/travis_cuda_install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
+CUDA_FILE=/tmp/cuda_install.deb
+curl $CUDA_URL -o $CUDA_FILE
+dpkg -i $CUDA_FILE
+rm -f $CUDA_FILE
+apt-get -y update
+apt-get -y install cuda-core-6-5 cuda-cublas-6-5 cuda-cublas-dev-6-5 cuda-cudart-6-5 cuda-cudart-dev-6-5 cuda-curand-6-5 cuda-curand-dev-6-5
+ln -s /usr/local/cuda-6.5 /usr/local/cuda

--- a/travis_cuda_install.sh
+++ b/travis_cuda_install.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+CUDA_VERSION=6-5
+
 CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
 CUDA_FILE=/tmp/cuda_install.deb
 curl $CUDA_URL -o $CUDA_FILE
 dpkg -i $CUDA_FILE
 rm -f $CUDA_FILE
 apt-get -y update
-apt-get -y install cuda-core-6-5 cuda-cublas-6-5 cuda-cublas-dev-6-5 cuda-cudart-6-5 cuda-cudart-dev-6-5 cuda-curand-6-5 cuda-curand-dev-6-5
+apt-get -y install \
+  cuda-core-${CUDA_VERSION} \
+  cuda-cublas-${CUDA_VERSION} \
+  cuda-cublas-dev-${CUDA_VERSION} \
+  cuda-cudart-${CUDA_VERSION} \
+  cuda-cudart-dev-${CUDA_VERSION} \
+  cuda-curand-${CUDA_VERSION} \
+  cuda-curand-dev-${CUDA_VERSION} \
+  cuda-cusparse-${CUDA_VERSION} \
+  cuda-cusparse-dev-${CUDA_VERSION} \
 ln -s /usr/local/cuda-6.5 /usr/local/cuda

--- a/travis_cuda_install.sh
+++ b/travis_cuda_install.sh
@@ -17,5 +17,5 @@ apt-get -y install \
   cuda-curand-${CUDA_VERSION} \
   cuda-curand-dev-${CUDA_VERSION} \
   cuda-cusparse-${CUDA_VERSION} \
-  cuda-cusparse-dev-${CUDA_VERSION} \
+  cuda-cusparse-dev-${CUDA_VERSION}
 ln -s /usr/local/cuda-6.5 /usr/local/cuda


### PR DESCRIPTION
This adds CUDA build tests. If something like https://github.com/torch/cunn/issues/264 happens we will track it down quickly.

Downsides:
 * cannot run with `sudo: false` because have to install cuda.
 * build is quite a bit slower because have to build cutorch and cunn for all archs

Other changes:
 * when running tests determine if need to run cuda tests by trying to require cutorch instead of playing with `nvcc` and `nvidia-smi`