### PR TITLE
Check for gnuplot existence before trying to remove it (fixes #109)

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -77,7 +77,7 @@ if [[ `uname` == 'Darwin' ]]; then
     brew install libjpeg imagemagick zeromq graphicsmagick openssl
     brew link readline --force
     brew cask install xquartz
-    brew remove gnuplot
+    brew list -1 | grep -q "^gnuplot\$" && brew remove gnuplot
     brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua
 
 elif [[ "$(uname)" == 'Linux' ]]; then


### PR DESCRIPTION
Execute `brew remove gnuplot` only in case it was not previously installed.