### PR TITLE
Fix premature exit with error when IPython is not installed

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -294,7 +294,7 @@ else
     exit 1
 fi
 
-ipython_exists=$(command -v ipython)
+ipython_exists=$(command -v ipython) || true
 if [[ $ipython_exists ]]; then {
     ipython_version=$(ipython --version|cut -f1 -d'.')
     if [[ $ipython_version != 2 && $ipython_version != 3 && $ipython_version != 4 ]]; then {


### PR DESCRIPTION
When no IPython was installed, the `install-dep` script always ended prematurely with the exit code 1, because it inherited the status of `command` in the following variable assignment:

```
ipython_exists=$(command -v ipython)
```