### PR TITLE
ipython version check for version ≥ 5

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -306,7 +306,7 @@ fi
 ipython_exists=$(command -v ipython) || true
 if [[ $ipython_exists ]]; then {
     ipython_version=$(ipython --version|cut -f1 -d'.')
-    if [[ $ipython_version != 2 && $ipython_version != 3 && $ipython_version != 4 ]]; then {
+    if [[ $ipython_version -lt 2 ]]; then {
         echo 'WARNING: Your ipython version is too old.  Type "ipython --version" to see this.  Should be at least version 2'
     } fi
 } fi


### PR DESCRIPTION
The install-deps script throws a warning when ipython version is ≥5

![2016-07-28-11-06-50](https://cloud.githubusercontent.com/assets/2303841/17207148/6d2bfba8-54b3-11e6-9434-d2b72f2d090e.png)
