### PR TITLE
Skip add torch to path for update

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,4 +3,4 @@
 git fetch
 git reset --hard origin/master
 # Submodule update is done inside install.sh
-./install.sh
+./install.sh -s


### PR DESCRIPTION
No need to re-add *Torch* to the path when updating it.
@albanD, I think you missed this one 😉 