### PR TITLE
add double quotes for blas/lapack libraries' path in torch's win patch

### DIFF
--- a/install-deps.bat
+++ b/install-deps.bat
@@ -246,7 +246,7 @@ if errorlevel 1 set TORCH_DEPENDENCIES=%TORCH_DEPENDENCIES% qt=4.8.7
 
 if not "%TORCH_DEPENDENCIES%" == "" (
   echo %ECHO_PREFIX% Installing %TORCH_DEPENDENCIES% by conda for Torch7
-  conda install -n %TORCH_CONDA_ENV% -c conda-forge %TORCH_DEPENDENCIES% --yes
+  conda install -n %TORCH_CONDA_ENV% -c conda-forge %TORCH_DEPENDENCIES% vc=%CONDA_VS_VERSION% --yes
 )
 
 :NO_CONDA

--- a/win-files/patch/torch.patch
+++ b/win-files/patch/torch.patch
@@ -25,7 +25,7 @@ index 95166ed..2dc307a 100644
    (destructor ? lua_pushcfunction(L, destructor) : lua_pushnil(L));
    (factory ? lua_pushcfunction(L, factory) : lua_pushnil(L));
 diff --git a/rocks/torch-scm-1.rockspec b/rocks/torch-scm-1.rockspec
-index 2228726..30df777 100644
+index 2228726..451f1aa 100644
 --- a/rocks/torch-scm-1.rockspec
 +++ b/rocks/torch-scm-1.rockspec
 @@ -27,7 +27,7 @@ cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release
@@ -33,7 +33,7 @@ index 2228726..30df777 100644
        windows = {
             build_command = [[
 -cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DLUA=$(LUA) -DLUALIB=$(LUALIB) -DLUA_BINDIR="$(LUA_BINDIR)" -DLUA_INCDIR="$(LUA_INCDIR)" -DLUA_LIBDIR="$(LUA_LIBDIR)" -DLUADIR="$(LUADIR)" -DLIBDIR="$(LIBDIR)" -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
-+cmake -E make_directory build && cd build && cmake .. -DINTEL_MKL_DIR=$(INTEL_MKL_DIR) -DINTEL_COMPILER_DIR=$(INTEL_COMPILER_DIR) -DBLAS_LIBRARIES=$(BLAS_LIBRARIES) -DLAPACK_LIBRARIES=$(LAPACK_LIBRARIES) -DLAPACK_FOUND=$(LAPACK_FOUND) -DCMAKE_BUILD_TYPE=Release -DLUA=$(LUA) -DLUALIB=$(LUALIB) -DLUA_BINDIR="$(LUA_BINDIR)" -DLUA_INCDIR="$(LUA_INCDIR)" -DLUA_LIBDIR="$(LUA_LIBDIR)" -DLUADIR="$(LUADIR)" -DLIBDIR="$(LIBDIR)" -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
++cmake -E make_directory build && cd build && cmake .. -DINTEL_MKL_DIR="$(INTEL_MKL_DIR)" -DINTEL_COMPILER_DIR="$(INTEL_COMPILER_DIR)" -DBLAS_LIBRARIES="$(BLAS_LIBRARIES)" -DLAPACK_LIBRARIES="$(LAPACK_LIBRARIES)" -DLAPACK_FOUND=$(LAPACK_FOUND) -DCMAKE_BUILD_TYPE=Release -DLUA=$(LUA) -DLUALIB=$(LUALIB) -DLUA_BINDIR="$(LUA_BINDIR)" -DLUA_INCDIR="$(LUA_INCDIR)" -DLUA_LIBDIR="$(LUA_LIBDIR)" -DLUADIR="$(LUADIR)" -DLIBDIR="$(LIBDIR)" -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
  ]]
        }
     },


### PR DESCRIPTION
This is only for installing torch on windows with msvc.