### PR TITLE
Fix package names in install-deps for elementary os.

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -227,7 +227,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
     elif [[ $distribution == 'elementary' ]]; then
         declare -a target_pkgs
         target_pkgs=( build-essential gcc g++ curl \
-                      cmake libreadline-dev git-core libqt4-core libqt4-gui \
+                      cmake libreadline-dev git-core libqtcore4 libqtgui4 \
                       libqt4-dev libjpeg-dev libpng-dev ncurses-dev \
                       imagemagick libzmq3-dev gfortran unzip gnuplot \
                       gnuplot-x11 ipython )


### PR DESCRIPTION
On Elementary Loki (based on Ubuntu 16.04 LTS), install-deps script does not work, because two package names are specified incorrectly.  The error messages are:

```
E: Unable to locate package libqt4-core
E: Unable to locate package libqt4-gui
```

This PR fixes the Elementary OS section.  I suspect the Ubuntu section is also broken. But since I don't have Ubuntu installed right now, I can't test that, so this PR only updates the elementary OS section. 

The correct package names are shown below: libqtcore4 and libqtgui4.

```
yz@yz-1070 [21:35:33] !221 ~  
$ uname -a
Linux yz-1070 4.4.0-53-generic #74-Ubuntu SMP Fri Dec 2 15:59:10 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
 
yz@yz-1070 [21:35:36] !222 ~  
$ uname -i
x86_64
 
yz@yz-1070 [21:35:38] !223 ~  
$ dpkg --get-selections | grep -i libqt
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
libqt4-dbus:amd64				install
libqt4-declarative:amd64			install
libqt4-designer:amd64				install
libqt4-dev					install
libqt4-dev-bin					install
libqt4-help:amd64				install
libqt4-network:amd64				install
libqt4-opengl:amd64				install
libqt4-opengl-dev				install
libqt4-qt3support:amd64				install
libqt4-script:amd64				install
libqt4-scripttools:amd64			install
libqt4-sql:amd64				install
libqt4-sql-mysql:amd64				install
libqt4-svg:amd64				install
libqt4-test:amd64				install
libqt4-xml:amd64				install
libqt4-xmlpatterns:amd64			install
libqt5core5a:amd64				install
libqt5dbus5:amd64				install
libqt5gui5:amd64				install
libqt5libqgtk2:amd64				install
libqt5multimedia5:amd64				install
libqt5multimedia5-plugins:amd64			install
libqt5multimediawidgets5:amd64			install
libqt5network5:amd64				install
libqt5opengl5:amd64				install
libqt5printsupport5:amd64			install
libqt5svg5:amd64				install
libqt5widgets5:amd64				install
libqt5x11extras5:amd64				install
libqt5xml5:amd64				install
libqtcore4:amd64				install
libqtdbus4:amd64				install
libqtgui4:amd64					install
```