### PR TITLE
Updated anaconda removal from PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ done
 # It has a malformed MKL library (as of 1/17/2015)
 OLDPATH=$PATH
 if [[ $(echo $PATH | grep conda) ]]; then
-    export PATH=$(echo $PATH | tr ':' '\n' | grep -v "conda[2-9]\?/bin" | grep -v "conda[2-9]\?/lib" | grep -v "conda[2-9]\?/include" | uniq | tr '\n' ':')
+    export PATH=$(echo $PATH | tr ':' '\n' | grep -v "conda[2-9]\?" | uniq | tr '\n' ':')
 fi
 
 echo "Prefix set to $PREFIX"


### PR DESCRIPTION
Older version does not account for multiple anaconda paths to different environments. Ex: anaconda3/envs/env_name/<bin,include,...> being there in addition to the default environment