### PR TITLE
Restore current directory in batch

### DIFF
--- a/install-deps.bat
+++ b/install-deps.bat
@@ -415,10 +415,12 @@ echo shift>> %CMAKE_CMD%
 echo cmake.exe .. -G "NMake Makefiles" %%*>> %CMAKE_CMD%
 
 set TORCH_SETUP_FAIL=0
+cd %TORCH_DISTRO%
 echo %ECHO_PREFIX% Setup succeed!
 goto :END
 
 :FAIL
+cd %TORCH_DISTRO%
 echo %ECHO_PREFIX% Setup fail!
 
 :END


### PR DESCRIPTION
On Windows, *install-deps.bat* doesn't restore current directory to *distro* root. I have fixed.
Note that the source code seems there are no related issue on other OS. (i.e. Linux)

I didn't put `cd %TORCH_DISTRO%` after `:END` on purpose, because the setup succeed or fail messages look beautiful when it appear at last.

Thanks.