### PR TITLE
Compatibility with Arch Linux. qtwebkit deprecated, using qt5-webkit-…

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -268,7 +268,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \
             imagemagick graphicsmagick fftw sox zeromq \
-            ipython qt4 qtwebkit || exit 1
+            ipython qt4 qt5-webkit-ng || exit 1
         pacman -Sl multilib &>/dev/null
         if [[ $? -ne 0 ]]; then
             gcc_package="gcc"


### PR DESCRIPTION
…ng instead

Hi,
I'm working on Arch Linux. Apparently the support for qtwebkit was removed from the official repos.
See: <https://bbs.archlinux.org/viewtopic.php?id=223045>
I found there that the new package qt5-webkit-ng is compatible with the previous one.

The only modification needed is on file install-deps, line 271:

```bash
ipython qt4 qt5-webkit-ng || exit 1

```
I've compiled it and it's working.
Regards,
José Enrique