### PR TITLE
Fix: ./install.sh: option requires an argument -- h

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ THIS_DIR=$(cd $(dirname $0); pwd)
 PREFIX=${PREFIX:-"${THIS_DIR}/install"}
 TORCH_LUA_VERSION=${TORCH_LUA_VERSION:-"LUAJIT21"} # by default install LUAJIT21
 
-while getopts 'bsh:' x; do
+while getopts 'bsh' x; do
     case "$x" in
         h)
             echo "usage: $0


### PR DESCRIPTION
Calling `install.sh -h` failed to show the script usage.
The -h option of install.sh did not work and script just went on with default settings.

From [getopt man page](https://linux.die.net/man/1/getopt):

> Each short option character in shortopts may be followed by one colon to indicate it  has  a
>               required argument, and by two colons to indicate it has an optional argument. 

`-h` option did not actually require argument but was followed by a colon, causing the error.
Thus, removed extraneous colon.

Result: calling `install.sh -h` now works, shows the script usage and stops the script as intended.
