### PR TITLE
Gracefully handle paths with spaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,7 +193,7 @@ fi
 
 WRITE_PATH_TO_PROFILE=0
 if [[ $BATCH_INSTALL == 0 ]]; then
-    if [ -f $RC_FILE ]; then
+    if [ -f "$RC_FILE" ]; then
         echo "
 
 Do you want to automatically prepend the Torch install location
@@ -216,7 +216,7 @@ to PATH and LD_LIBRARY_PATH in your $RC_FILE? (yes/no)
         fi
     fi
 else
-    if [[ $RC_FILE ]]; then
+    if [[ "$RC_FILE" ]]; then
         WRITE_PATH_TO_PROFILE=1
     fi
 fi
@@ -224,7 +224,7 @@ fi
 if [[ $WRITE_PATH_TO_PROFILE == 1 ]]; then
     echo "
 
-. $PREFIX/bin/torch-activate" >> $RC_FILE
+. $PREFIX/bin/torch-activate" >> "$RC_FILE"
     echo "
 
 . $PREFIX/bin/torch-activate" >> "$HOME"/.profile

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,12 @@ SKIP_RC=0
 BATCH_INSTALL=0
 
 THIS_DIR=$(cd $(dirname $0); pwd)
+if [[ "$THIS_DIR" == *" "* ]]; then
+    echo "$THIS_DIR: Torch cannot install to a path containing whitespace.
+Please try a different path, one without any spaces.
+"
+    exit 1
+fi
 PREFIX=${PREFIX:-"${THIS_DIR}/install"}
 TORCH_LUA_VERSION=${TORCH_LUA_VERSION:-"LUAJIT21"} # by default install LUAJIT21
 

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,7 @@ BATCH_INSTALL=0
 THIS_DIR=$(cd $(dirname $0); pwd)
 if [[ "$THIS_DIR" == *" "* ]]; then
     echo "$THIS_DIR: Torch cannot install to a path containing whitespace.
-Please try a different path, one without any spaces.
-"
+Please try a different path, one without any spaces."
     exit 1
 fi
 PREFIX=${PREFIX:-"${THIS_DIR}/install"}

--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ if [[ $WRITE_PATH_TO_PROFILE == 1 ]]; then
 . $PREFIX/bin/torch-activate" >> $RC_FILE
     echo "
 
-. $PREFIX/bin/torch-activate" >> $HOME/.profile
+. $PREFIX/bin/torch-activate" >> "$HOME"/.profile
 
 else
     echo "


### PR DESCRIPTION
Older versions of macOS allowed spaces in the username, and these accounts propagate forward on upgrades.

Such a user might get a cryptic bash error when attempt to install, so instead it should print out clear instructions to try another path. Meanwhile, the automatic edits to `~/.bashrc` should be made to work even if there is a space in `$HOME`.

Full support for spaces in the torch install path would unfortunately require more extensive changes downstream.