### PR TITLE
Add debian sid support

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -366,7 +366,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
 
         install_openblas || true
     elif [[ $distribution == 'debian' ]]; then
-	if [[ $debian_major_version == '8' ]]; then
+	if [[ $debian_major_version == '8' ]] || [[ $debian_major_version == '9' ]]; then
 	    echo "==> Found Debian version ${debian_major_version}"
 	    if sudo apt-get update ; then
 	       echo "Updated successfully."
@@ -384,7 +384,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
 
 	    install_openblas || true
 	else
-	    echo "Only Jessie Debian 8 is supported for now, aborting."
+	    echo "Only Jessie Debian 8 and 9 is supported for now, aborting."
 	    exit 1
 	fi
     fi

--- a/install-deps
+++ b/install-deps
@@ -8,25 +8,42 @@ set -e
 
 install_openblas() {
     # Get and build OpenBlas (Torch is much better with a decent Blas)
-    cd /tmp/
-    rm -rf OpenBLAS
-    git clone https://github.com/xianyi/OpenBLAS.git
-    cd OpenBLAS
-    if [ $(getconf _NPROCESSORS_CONF) == 1 ]; then
-        make NO_AFFINITY=1 USE_OPENMP=0 USE_THREAD=0
+    # Optionally set environment variable PREFIX to control
+    # the installation directory.
+
+
+    local PATH=$PATH:/sbin ## improve chances of finding ldconfig
+    # Only proceed installing OpenBLAS if either ldconfig is unavailable, or ldconfig
+    # reports that OpenBLAS is not already installed.
+    if ! type ldconfig >/dev/null || ! ldconfig -p | grep -q "lib\(open\)\?blas.so"; then
+        local tempdir=$(mktemp -d)
+
+        git clone https://github.com/xianyi/OpenBLAS.git "$tempdir"/OpenBLAS  || { echo "Error. Cannot clone OpenBLAS." >&2 ; exit 1 ; }
+        cd "$tempdir"/OpenBLAS || { echo "Error. Cannot create tempdir." >&2 ; exit 1 ; }
+        if [ $(getconf _NPROCESSORS_CONF) == 1 ]; then
+            make NO_AFFINITY=1 USE_OPENMP=0 USE_THREAD=0
+        else
+            make NO_AFFINITY=1 USE_OPENMP=1
+        fi
+        RET=$?;
+        if [ $RET -ne 0 ]; then
+            echo "Error. OpenBLAS could not be compiled";
+            exit $RET;
+        fi
+        if [ ! -z "$PREFIX" ]; then
+            sudo make install PREFIX="$PREFIX"
+        else
+            sudo make install
+        fi
+        RET=$?;
+        if [ $RET -ne 0 ]; then
+            echo "Error. OpenBLAS could not be installed";
+            exit $RET;
+        fi
+        cd -
+        rm -rf "$tempdir"
     else
-        make NO_AFFINITY=1 USE_OPENMP=1
-    fi
-    RET=$?;
-    if [ $RET -ne 0 ]; then
-        echo "Error. OpenBLAS could not be compiled";
-        exit $RET;
-    fi
-    sudo make install
-    RET=$?;
-    if [ $RET -ne 0 ]; then
-        echo "Error. OpenBLAS could not be installed";
-        exit $RET;
+        echo "Skipping install of OpenBLAS - it is already installed." >&2
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ fi
 echo "Prefix set to $PREFIX"
 
 if [[ `uname` == 'Linux' ]]; then
-    export CMAKE_LIBRARY_PATH=/opt/OpenBLAS/include:/opt/OpenBLAS/lib:$CMAKE_LIBRARY_PATH
+    export CMAKE_LIBRARY_PATH=$PREFIX/include:/opt/OpenBLAS/include:$PREFIX/lib:/opt/OpenBLAS/lib:$CMAKE_LIBRARY_PATH
 fi
 export CMAKE_PREFIX_PATH=$PREFIX
 


### PR DESCRIPTION
### - What I did
Noticing that the install-deps script installed OpenBLAS even though I already have it installed, I changed the script to detect an existing installation of OpenBLAS, and skip performing a redundant installation.

I also noticed that the install-deps script worked just as well with Debian 9 (sid) as with Debian 8, so I added Debian 9 as an accepted OS.

### - How I did it
Installation of OpenBLAS is performed if either ldconfig is not found, or ldconfig reports no OpenBLAS presense.
```
    if ! type ldconfig >/dev/null || ! ldconfig -p | grep -q libblas.so; then
```

### - How to verify it
 1. Running the installation with OpenBLAS already installed, will skip another installation with the message "Skipping install of OpenBLAS - it is already installed."
 2. Run the installation on Debian 9 (sid). It now proceeds instead of aborting the installation.

### - Description for the changelog
Improve OpenBLAS dependency installation.
Accept Debian 9 as a recognised OS.