### PR TITLE
Fix to Support building on p2(AWS EC2 Instance type) for multiple CUDA Architectures

### DIFF
--- a/cmake/3.6/Modules/FindCUDA/select_compute_arch.cmake
+++ b/cmake/3.6/Modules/FindCUDA/select_compute_arch.cmake
@@ -88,7 +88,9 @@ endfunction()
 # Usage:
 #   SELECT_NVCC_ARCH_FLAGS(out_variable [list of CUDA compute archs])
 function(CUDA_SELECT_NVCC_ARCH_FLAGS out_variable)
-  set(CUDA_ARCH_LIST "${ARGN}")
+  if(ARGN)
+    set(CUDA_ARCH_LIST "${ARGN}")
+  endif()
 
   if("X${CUDA_ARCH_LIST}" STREQUAL "X" )
     set(CUDA_ARCH_LIST "Auto")


### PR DESCRIPTION
This fix allows us to pass CUDA_ARCH_LIST=Common when building cutorch and cunn and thus allowing us to build for multiple CUDA Architectures instead of just sm_37(Autodetected). Without this fix, the passed value for the parameter CUDA_ARCH_LIST gets overwritten. More details on the issue I was facing with building on p2 and testing on g2(AWS E2 Instance): https://groups.google.com/forum/#!topic/torch7/799oxbqHkus