### PR TITLE
torch-activate: Never add the current directory to LD_LIBRARY_PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -163,10 +163,10 @@ fi
 
 cat <<EOF >$PREFIX/bin/torch-activate
 $setup_lua_env_cmd
-export PATH=$PREFIX/bin:\$PATH
-export LD_LIBRARY_PATH=$PREFIX/lib:\$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=$PREFIX/lib:\$DYLD_LIBRARY_PATH
-export LUA_CPATH='$CLIB_LUA_CPATH;'\$LUA_CPATH
+export PATH=$PREFIX/bin\${PATH:+:\$PATH}
+export LD_LIBRARY_PATH=$PREFIX/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
+export DYLD_LIBRARY_PATH=$PREFIX/lib\${DYLD_LIBRARY_PATH:+:\$DYLD_LIBRARY_PATH}
+export LUA_CPATH='$CLIB_LUA_CPATH'\${LUA_CPATH:+;\$LUA_CPATH}
 EOF
 chmod +x $PREFIX/bin/torch-activate
 


### PR DESCRIPTION
The dynamic loader parses a `:` at the end of LD_LIBRARY_PATH as a separator delimiting the empty string on its right, which is interpreted as the current directory.  This can cause all kinds of hard-to-debug breakage and may be a security vulnerability in certain contexts.  See:

https://joshumax.github.io/general/2017/06/08/how-torch-broke-ls.html

Correct this using the `${parameter:+word}` syntax, which works in all POSIX shells:

http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02