### PR TITLE
qt5-webkit-ng replaced by qt5-webkit

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -285,7 +285,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             cmake curl readline ncurses git \
             gnuplot unzip libjpeg-turbo libpng libpng \
             imagemagick graphicsmagick fftw sox zeromq \
-            ipython qt4 qt5-webkit-ng || exit 1
+            ipython qt4 qt5-webkit || exit 1
         pacman -Sl multilib &>/dev/null
         if [[ $? -ne 0 ]]; then
             gcc_package="gcc"


### PR DESCRIPTION
See [this archlinux package page](https://www.archlinux.org/packages/extra/x86_64/qt5-webkit/).