### PR TITLE
install-deps script now works also with Fedora 26

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -312,17 +312,9 @@ elif [[ "$(uname)" == 'Linux' ]]; then
                                 qt-devel qtwebkit-devel sox-plugins-freeworld \
                                 ipython
             install_openblas || true
-        elif [[ $fedora_major_version == '22' ||  $fedora_major_version == '23' ]]; then
+        elif [[ $fedora_major_version -ge '22' ||  $fedora_major_version -le '26' ]]; then
             #using dnf - since yum has been deprecated
             #sox-plugins-freeworld is not yet available in repos for F22
-            sudo dnf install -y make cmake curl readline-devel ncurses-devel \
-                                gcc-c++ gcc-gfortran git gnuplot unzip \
-                                libjpeg-turbo-devel libpng-devel \
-                                ImageMagick GraphicsMagick-devel fftw-devel \
-                                sox-devel sox qt-devel qtwebkit-devel \
-                                python-ipython czmq czmq-devel
-            install_openblas || true
-        elif [[ $fedora_major_version == '24' ||  $fedora_major_version == '25' ]]; then
             sudo dnf install -y make cmake curl readline-devel ncurses-devel \
                                 gcc-c++ gcc-gfortran git gnuplot unzip \
                                 libjpeg-turbo-devel libpng-devel \


### PR DESCRIPTION
Previously, all the commands for Fedora 22 and 23 were completely the same as for Fedora 24 and 25, so I merged them into one big "interval" condition to make the code more DRY.

I verified that it installs on F26