### PR TITLE
Add Moses dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "extra/lua-cjson"]
 	path = extra/lua-cjson
 	url = https://github.com/mpx/lua-cjson
+[submodule "extra/moses"]
+	path = extra/moses
+	url = https://github.com/Yonaba/Moses.git

--- a/install.sh
+++ b/install.sh
@@ -122,6 +122,7 @@ cd ${THIS_DIR}/pkg/dok       && $PREFIX/bin/luarocks make rocks/dok-scm-1.rocksp
 cd ${THIS_DIR}/exe/trepl     && $PREFIX/bin/luarocks make trepl-scm-1.rockspec         || exit 1
 cd ${THIS_DIR}/pkg/sys       && $PREFIX/bin/luarocks make sys-1.1-0.rockspec           || exit 1
 cd ${THIS_DIR}/pkg/xlua      && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec          || exit 1
+cd ${THIS_DIR}/extra/moses   && $PREFIX/bin/luarocks make rockspec/moses-1.6.1-1.rockspec || exit 1
 cd ${THIS_DIR}/extra/nn      && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec      || exit 1
 cd ${THIS_DIR}/extra/graph   && $PREFIX/bin/luarocks make rocks/graph-scm-1.rockspec   || exit 1
 cd ${THIS_DIR}/extra/nngraph && $PREFIX/bin/luarocks make nngraph-scm-1.rockspec       || exit 1


### PR DESCRIPTION
The distro is missing the Moses package, and the included version of luarocks is unable to download it, so installation fails. This patch fixes the issue by adding a submodule for moses and installing it before nn.

This should also fix issues torch/torch7#1045 and torch/nn#1219.

The installation failure I got looks like this: 

> Missing dependencies for nn:
> moses >= 1.0
> 
> Warning: Failed searching manifest: Failed loading manifest for https://raw.githubusercontent.com/torch/rocks/master: Error loading file: [string "/Users/camillol/.cache/luarocks/https___raw.g..."]:1: unexpected symbol near 'char(31)'
> Warning: Failed searching manifest: Failed loading manifest for https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master: Error loading file: [string "/Users/camillol/.cache/luarocks/https___raw.g..."]:1: unexpected symbol near 'char(31)'
> 
> Error: Could not satisfy dependency: moses >= 1.0
