### PR TITLE
[install_deps] Avoid break on new Docker Ubuntu images

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -175,7 +175,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             echo "Some portion of the update is failed"
         fi
         # python-software-properties is required for apt-add-repository
-        sudo apt-get install -y python-software-properties
+        sudo apt-get install -y python-software-properties || true
         echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
         if [[ $ubuntu_major_version -lt '12' ]]; then
             echo '==> Ubuntu version not supported.'
@@ -258,7 +258,7 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             echo "Some portion of the update is failed"
         fi
         # python-software-properties is required for apt-add-repository
-        sudo apt-get install -y python-software-properties
+        sudo apt-get install -y python-software-properties || true
         if [[ $elementary_version == '0.3' ]]; then
             echo '==> Found Ubuntu version 14.xx based elementary installation, installing dependencies'
             sudo apt-get install -y software-properties-common \


### PR DESCRIPTION
Little trick to make `docker build` works using recent Ubuntu images (>=17).