### PR TITLE
Fixing install-deps script for Ubuntu 18

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -175,7 +175,10 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             echo "Some portion of the update is failed"
         fi
         # python-software-properties is required for apt-add-repository
-        sudo apt-get install -y python-software-properties
+        if [[ $ubuntu_major_version -ne '18' ]]; then
+            sudo apt-get install -y python-software-properties
+        fi
+
         echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
         if [[ $ubuntu_major_version -lt '12' ]]; then
             echo '==> Ubuntu version not supported.'


### PR DESCRIPTION
In Ubuntu 18, `python-software-properties` has been moved to `software-properties-common`.  The line: `sudo apt-get install -y python-software-properties` causes the install-deps script to fail on Ubuntu 18. I added a line to fix the build on Ubuntu 18 without breaking the build for previous versions of Ubuntu.