### PR TITLE
Fixed Ubuntu 'python-software-properties Not Found'

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -175,8 +175,10 @@ elif [[ "$(uname)" == 'Linux' ]]; then
             echo "Some portion of the update is failed"
         fi
         # python-software-properties is required for apt-add-repository
+	set +e
         sudo apt-get install -y python-software-properties
-        echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
+        set -e
+	echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
         if [[ $ubuntu_major_version -lt '12' ]]; then
             echo '==> Ubuntu version not supported.'
             exit 1


### PR DESCRIPTION
Om Ubuntu 18.04, an error would occur where python-software-properties was not found. The next part of the script accounted for this, but "set +e" was not called, so the script crashed instead of properly handling the missing package.