### PR TITLE
Remove python-software-properties from deps for ubuntu 18+

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -174,9 +174,11 @@ elif [[ "$(uname)" == 'Linux' ]]; then
         else
             echo "Some portion of the update is failed"
         fi
-        # python-software-properties is required for apt-add-repository
-        sudo apt-get install -y python-software-properties
         echo "==> Found Ubuntu version ${ubuntu_major_version}.xx"
+        # python-software-properties is required for apt-add-repository
+        if [[ $ubuntu_major_version -lt '18' ]]; then
+            sudo apt-get install -y python-software-properties
+        fi
         if [[ $ubuntu_major_version -lt '12' ]]; then
             echo '==> Ubuntu version not supported.'
             exit 1


### PR DESCRIPTION
The package: python-software-properties is not included in Ubuntu 18+, but is not necessary for the dependency install script to work.