### PR TITLE
Fixed deps installation errors on MacOSX 10.15.7

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -93,9 +93,9 @@ if [[ `uname` == 'Darwin' ]]; then
     brew install git readline cmake wget
     brew install libjpeg imagemagick zeromq graphicsmagick openssl
     brew link readline --force
-    brew cask install xquartz
-    brew list -1 | grep -q "^gnuplot\$" && brew remove gnuplot
-    brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua
+    brew install --cask xquartz
+    brew list --formula | grep -q "^gnuplot\$" && brew remove gnuplot
+    brew install gnuplot
     brew install qt || true
 
 elif [[ "$(uname)" == 'Linux' ]]; then


### PR DESCRIPTION
Hello,
I tried to install torch7 on my workstation and was getting errors while running "bash install-deps". I was following this [article](http://torch.ch/docs/getting-started.html).

To fix the errors I've applied the following changes:
1. Fixed brew cask installation error
2. Fixed incorrect usage of brew list
3. Removed extra parameters from gnuplot install command

Tested on MacOSX 10.15.7
Homebrew 2.7.1
Homebrew/homebrew-core (git revision adc0a; last commit 2021-01-03)
Homebrew/homebrew-cask (git revision d89d38; last commit 2021-01-03)

Please, let me know if you have any suggestions, especially regarding [gnuplot](https://formulae.brew.sh/formula/gnuplot)...