### PR TITLE
Update install-deps, remove old brew cask command

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -93,7 +93,7 @@ if [[ `uname` == 'Darwin' ]]; then
     brew install git readline cmake wget
     brew install libjpeg imagemagick zeromq graphicsmagick openssl
     brew link readline --force
-    brew cask install xquartz
+    brew install --cask xquartz
     brew list -1 | grep -q "^gnuplot\$" && brew remove gnuplot
     brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua
     brew install qt || true


### PR DESCRIPTION
I have made this change: 
`brew cask install xquartz` --> `brew install --cask xquartz`
to avoid installation error on macOS: 
`Error: "brew cask" is no longer a "brew" command. Use "brew <command> --cask" instead.`

The issue was here: https://github.com/torch/torch7/issues/1234